### PR TITLE
Fixed typo when selecting gender

### DIFF
--- a/individual/add.php
+++ b/individual/add.php
@@ -87,7 +87,7 @@
 					<div class="span8">
 						<select class="selectpicker" name="gender">
 							<option value="MALE">Male</option>
-							<option value="MALE">Female</option>
+							<option value="FEMALE">Female</option>
 						</select>
 					</div>
 				</div>


### PR DESCRIPTION
When female was selected the value was set to MALE instead of FEMALE.